### PR TITLE
Fix aggregate root version

### DIFF
--- a/src/LaravelMessageRepository.php
+++ b/src/LaravelMessageRepository.php
@@ -59,9 +59,12 @@ final class LaravelMessageRepository implements MessageRepository
             ->where('event_stream', $id->toString())
             ->orderBy('recorded_at')
             ->get('payload');
+        $payloadsCount = $payloads->count();
 
         foreach ($payloads as $payload) {
             yield from $this->serializer->unserializePayload(json_decode($payload->payload, true));
+
+            return $payloadsCount;
         }
     }
 


### PR DESCRIPTION
After update i have a problem my aggregate roots always version 0.

The problem occurs when after applying all events here ```\EventSauce\EventSourcing\AggregateRootBehaviour::apply```
```\EventSauce\EventSourcing\AggregateRootBehaviour::$aggregateRootVersion``` property sets again to 0 here
```\EventSauce\EventSourcing\AggregateRootBehaviour::reconstituteFromEvents``` because 
```\EventSauce\LaravelEventSauce\LaravelMessageRepository::retrieveAll``` returned generator has no 'return' keyword