### PR TITLE
Ramsey UUID v4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/container": "^7.0",
         "illuminate/queue": "^7.0",
         "illuminate/support": "^7.0",
-        "ramsey/uuid": "^3.8"
+        "ramsey/uuid": "^3.8|^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
Already supported on the eventsauce core library.