### PR TITLE
Remove incremental id from table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /phpunit.xml
 .phpunit.result.cache
 .php_cs.cache
+/.idea

--- a/database/migrations/2018_08_31_104000_create_domain_messages_table.php
+++ b/database/migrations/2018_08_31_104000_create_domain_messages_table.php
@@ -9,8 +9,7 @@ final class CreateDomainMessagesTable extends Migration
     public function up()
     {
         Schema::create('domain_messages', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->string('event_id', 36);
+            $table->uuid('event_id')->primary();
             $table->string('event_type', 100);
             $table->string('event_stream', 36)->index();
             $table->dateTime('recorded_at', 6)->index();

--- a/src/Console/stubs/create_domain_messages_table.php.stub
+++ b/src/Console/stubs/create_domain_messages_table.php.stub
@@ -9,8 +9,7 @@ class {{ migration }} extends Migration
     public function up()
     {
         Schema::create('{{ table }}', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->string('event_id', 36);
+            $table->uuid('event_id')->primary();
             $table->string('event_type', 100);
             $table->string('event_stream', 36)->index();
             $table->dateTime('recorded_at', 6)->index();

--- a/tests/AggregateRootRepositoryTest.php
+++ b/tests/AggregateRootRepositoryTest.php
@@ -27,8 +27,7 @@ class AggregateRootRepositoryTest extends TestCase
         parent::setUp();
 
         Schema::create('event_store', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->string('event_id', 36);
+            $table->uuid('event_id')->primary();
             $table->string('event_type', 100);
             $table->string('event_stream', 36)->nullable()->index();
             $table->dateTime('recorded_at', 6)->index();
@@ -75,7 +74,6 @@ class AggregateRootRepositoryTest extends TestCase
         $this->persistAggregate(RegistrationAggregateRootRepository::class);
 
         $this->assertDatabaseHas('domain_messages', [
-            'id' => 1,
             'event_type' => 'tests.fixtures.user_was_registered',
         ]);
     }
@@ -121,7 +119,6 @@ class AggregateRootRepositoryTest extends TestCase
         $this->persistAggregate(RepositoryWithCustomConnection::class);
 
         $this->assertDatabaseHas('domain_messages', [
-            'id' => 1,
             'event_type' => 'tests.fixtures.user_was_registered',
         ], $connection);
     }
@@ -132,7 +129,6 @@ class AggregateRootRepositoryTest extends TestCase
         $this->persistAggregate(RepositoryWithCustomTable::class);
 
         $this->assertDatabaseHas('event_store', [
-            'id' => 1,
             'event_type' => 'tests.fixtures.user_was_registered',
         ]);
     }

--- a/tests/LaravelMessageRepositoryTest.php
+++ b/tests/LaravelMessageRepositoryTest.php
@@ -37,7 +37,6 @@ class LaravelMessageRepositoryTest extends TestCase
         $this->repository->persist($message);
 
         $this->assertDatabaseHas('domain_messages', [
-            'id' => 1,
             'event_type' => 'tests.fixtures.user_was_registered',
         ]);
     }


### PR DESCRIPTION
This PR removes the incremental id column from the message storage and converts the message-id to a UUID type. 

This PR wouldn't be a breaking change since a user is free to create a message table with an incremental id. It wouldn't break already existing tables that have an incremental id. 