### PR TITLE
Fix message storage of recorded at for mysql 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,6 @@ jobs:
           - php: 8.1
             laravel: 8
             code-gen: 'no'
-            eventsauce: '^0.8.2'
-          - php: 8.1
-            laravel: 8
-            code-gen: 'no'
             eventsauce: '^1.2.0'
 
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,10 +28,6 @@ jobs:
             laravel: 8
             code-gen: 'no'
             eventsauce: '^1.2.0'
-          - php: 7.4
-            laravel: 8
-            code-gen: 'no'
-            eventsauce: '^0.8.2'
 
 
     name: PHP ${{ matrix.php }} - L ${{ matrix.laravel }} - E ${{ matrix.eventsauce }} - CG ${{ matrix.code-gen }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: true
       matrix:
         php: ['8.0', 8.1]
-        eventsauce: ['^0.8.2', '^1.2.0']
+        eventsauce: ['^1.2.0']
         code-gen: ['^1.0']
         laravel: [8]
         include:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 /phpunit.xml
 .phpunit.result.cache
 .php_cs.cache
+/.idea

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
-        "eventsauce/eventsauce": "^0.8.2|^1.0.0",
+        "eventsauce/eventsauce": "^1.0.0",
         "illuminate/bus": "^8.0",
         "illuminate/container": "^8.0",
         "illuminate/queue": "^8.0",

--- a/src/LaravelMessageRepository.php
+++ b/src/LaravelMessageRepository.php
@@ -45,11 +45,7 @@ final class LaravelMessageRepository implements MessageRepository
                 'event_id' => $headers[Header::EVENT_ID] ?? Uuid::uuid4()->toString(),
                 'event_type' => $headers[Header::EVENT_TYPE],
                 'event_stream' => $message->aggregateRootId()->toString(),
-                // The interface for timeOfRecording changed from version 0.8 to 1.2.
-                // Since this package supports both versions, we have to check the class timeOfRecording returns.
-                'recorded_at' => $message->timeOfRecording() instanceof PointInTime 
-                    ? $message->timeOfRecording()->dateTime()->format('Y-m-d H:i:s.u')
-                    : $message->timeOfRecording()->format('Y-m-d H:i:s.u'),
+                'recorded_at' => $message->timeOfRecording()->format('Y-m-d H:i:s.u'),
                 'payload' => json_encode($this->serializer->serializeMessage($message)),
             ]);
         });

--- a/src/LaravelMessageRepository.php
+++ b/src/LaravelMessageRepository.php
@@ -8,6 +8,7 @@ use EventSauce\EventSourcing\AggregateRootId;
 use EventSauce\EventSourcing\Header;
 use EventSauce\EventSourcing\Message;
 use EventSauce\EventSourcing\MessageRepository;
+use EventSauce\EventSourcing\PointInTime;
 use EventSauce\EventSourcing\Serialization\MessageSerializer;
 use Exception;
 use Generator;
@@ -44,7 +45,11 @@ final class LaravelMessageRepository implements MessageRepository
                 'event_id' => $headers[Header::EVENT_ID] ?? Uuid::uuid4()->toString(),
                 'event_type' => $headers[Header::EVENT_TYPE],
                 'event_stream' => $message->aggregateRootId()->toString(),
-                'recorded_at' => $message->timeOfRecording()->format('Y-m-d H:i:s.u'),
+                // The interface for timeOfRecording changed from version 0.8 to 1.2.
+                // Since this package supports both versions, we have to check the class timeOfRecording returns.
+                'recorded_at' => $message->timeOfRecording() instanceof PointInTime 
+                    ? $message->timeOfRecording()->dateTime()->format('Y-m-d H:i:s.u')
+                    : $message->timeOfRecording()->format('Y-m-d H:i:s.u'),
                 'payload' => json_encode($this->serializer->serializeMessage($message)),
             ]);
         });

--- a/src/LaravelMessageRepository.php
+++ b/src/LaravelMessageRepository.php
@@ -38,17 +38,14 @@ final class LaravelMessageRepository implements MessageRepository
     {
         $connection = $this->connection();
 
-        collect($messages)->map(function (Message $message) {
-            return $this->serializer->serializeMessage($message);
-        })->each(function (array $message) use ($connection) {
-            $headers = $message['headers'];
-
+        collect($messages)->each(function (Message $message) use ($connection) {
+            $headers = $message->headers();
             $connection->table($this->table)->insert([
                 'event_id' => $headers[Header::EVENT_ID] ?? Uuid::uuid4()->toString(),
                 'event_type' => $headers[Header::EVENT_TYPE],
-                'event_stream' => $headers[Header::AGGREGATE_ROOT_ID] ?? null,
-                'recorded_at' => $headers[Header::TIME_OF_RECORDING],
-                'payload' => json_encode($message),
+                'event_stream' => $message->aggregateRootId()->toString(),
+                'recorded_at' => $message->timeOfRecording()->format('Y-m-d H:i:s.u'),
+                'payload' => json_encode($this->serializer->serializeMessage($message)),
             ]);
         });
     }


### PR DESCRIPTION
This small change in the `LaravelMessageRepository` will fix the issue with mysql8 datetime: 

Issue in LaravelEventSauce https://github.com/EventSaucePHP/LaravelEventSauce/issues/25 
"parent" issue in EventSauce: https://github.com/EventSaucePHP/EventSauce/issues/108

I'm aware of the `MySQL8DateFormatting` but I think formatting the date in the right way for the storage should be a concern of the repository. 

Besides that, I think this would improve the onboarding experience of new users of this package. 

