### PR TITLE
Laravel 9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,20 +15,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: ['8.0', 8.1]
-        eventsauce: ['^0.8.2', '^1.2.0']
+        php: [8.0, 8.1]
+        eventsauce: ['^1.2.0']
         code-gen: ['^1.0']
-        laravel: [8]
-        include:
-          - php: 8.1
-            laravel: 8
-            code-gen: 'no'
-            eventsauce: '^1.2.0'
-          - php: 7.4
-            laravel: 8
-            code-gen: 'no'
-            eventsauce: '^0.8.2'
-
+        laravel: [8, 9]
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 
@@ -48,7 +38,7 @@ jobs:
           composer require "eventsauce/eventsauce=${{ matrix.eventsauce }}" -w --prefer-dist --no-interaction --no-update
 
       - name: Install code-generation
-        if: ${{ matrix.code-gen != 'no' && matrix.eventsauce != '^0.8.2' }}
+        if: ${{ matrix.code-gen != 'no' }}
         run: |
           composer require "eventsauce/code-generation=${{ matrix.code-gen }}" -w --prefer-dist --no-interaction --no-update
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "eventsauce/eventsauce": "^1.0.0",
+        "eventsauce/eventsauce": "^1.2",
         "illuminate/bus": "^9.0",
         "illuminate/container": "^9.0",
         "illuminate/queue": "^9.0",

--- a/composer.json
+++ b/composer.json
@@ -19,17 +19,17 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "ext-json": "*",
-        "eventsauce/eventsauce": "^0.8.2|^1.0.0",
-        "illuminate/bus": "^8.0",
-        "illuminate/container": "^8.0",
-        "illuminate/queue": "^8.0",
-        "illuminate/support": "^8.0",
+        "eventsauce/eventsauce": "^1.0.0",
+        "illuminate/bus": "^9.0",
+        "illuminate/container": "^9.0",
+        "illuminate/queue": "^9.0",
+        "illuminate/support": "^9.0",
         "ramsey/uuid": "^3.8|^4.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.3"
     },
     "suggest": {


### PR DESCRIPTION
Good morning @frankdejonge !

I was finalizing this PR when I noticed #34 . So... you have options 😉 

To keep things tidy, this particular PR deprecates support for:

- Laravel 8
- PHP 7.4 (deprecated by Laravel 9)

This also allows for a more compact GitHub Action setup.